### PR TITLE
Expand UniFi Drive API client and document additional endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ These options can be adjusted later from the integration's options dialog.
 - Run static type checking or linting tools as needed.  There are currently no automated tests in the repository.
 - Implement Websocket instead of Polling
 
+## Additional UniFi Drive API endpoints to explore
+
+The REST surface exposed under `/proxy/drive/api/v2/` is broader than the handful of resources currently consumed by this integration.  When expanding sensor or binary sensor coverage it is worth inspecting the responses from these commonly observed endpoints:
+
+- `GET /proxy/drive/api/v2/storage/pools` – detailed RAID/pool health and redundancy metadata.
+- `GET /proxy/drive/api/v2/storage/tasks` – asynchronous storage tasks such as scrubs, rebuilds, and formatting jobs.
+- `GET /proxy/drive/api/v2/alerts` – active alerts and warning notifications raised by UniFi Drive.
+- `GET /proxy/drive/api/v2/settings` – global appliance settings, including update channels and power profiles.
+- `GET /proxy/drive/api/v2/systems/led` – enclosure LED status and current behaviour.
+
+Capturing these endpoints while logged into the UniFi OS web UI (for example via the browser's developer tools) will reveal the exact payload shape returned by your firmware version.
+
 ## License
 
 This project is provided as-is without an explicit license.  Please open an issue or submit a PR if you would like to contribute improvements.

--- a/api.py
+++ b/api.py
@@ -41,6 +41,8 @@ class UniFiDriveClient:
     async def close(self) -> None:
         if self._session and not self._session.closed:
             await self._session.close()
+        self._session = None
+        self._csrf = None
 
     async def login(self) -> None:
         """Perform login to obtain TOKEN cookie and X-Csrf-Token header."""
@@ -110,14 +112,46 @@ class UniFiDriveClient:
     async def get_fan_control(self) -> dict[str, Any]:
         return await self._get_or_empty("/proxy/drive/api/v2/systems/fan-control", {})
 
+    async def get_storage_pools(self) -> Any:
+        return await self._get_or_empty("/proxy/drive/api/v2/storage/pools", [])
+
+    async def get_storage_tasks(self) -> Any:
+        return await self._get_or_empty("/proxy/drive/api/v2/storage/tasks", [])
+
+    async def get_alerts(self) -> Any:
+        return await self._get_or_empty("/proxy/drive/api/v2/alerts", [])
+
+    async def get_settings(self) -> dict[str, Any]:
+        return await self._get_or_empty("/proxy/drive/api/v2/settings", {})
+
+    async def get_system_led(self) -> dict[str, Any]:
+        return await self._get_or_empty("/proxy/drive/api/v2/systems/led", {})
+
     async def get_all(self) -> dict[str, Any]:
-        dev, storage_root, shares, vols, drives, fan = await asyncio.gather(
+        (
+            dev,
+            storage_root,
+            shares,
+            vols,
+            drives,
+            fan,
+            pools,
+            tasks,
+            alerts,
+            settings,
+            led,
+        ) = await asyncio.gather(
             self.get_device_info(),
             self.get_storage_root(),
             self.get_storage_shares(),
             self.get_storage_volumes(),
             self.get_drives(),
             self.get_fan_control(),
+            self.get_storage_pools(),
+            self.get_storage_tasks(),
+            self.get_alerts(),
+            self.get_settings(),
+            self.get_system_led(),
         )
         return {
             "device": dev,
@@ -126,4 +160,9 @@ class UniFiDriveClient:
             "volumes": vols,
             "drives": drives,
             "fan_control": fan,
+            "storage_pools": pools,
+            "storage_tasks": tasks,
+            "alerts": alerts,
+            "settings": settings,
+            "system_led": led,
         }


### PR DESCRIPTION
## Summary
- extend the UniFi Drive API client to expose additional REST endpoints and clear session state on close
- document commonly observed UniFi Drive API endpoints for future sensor and binary sensor coverage

## Testing
- python -m compileall api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691396b45944832d92ae4bdd8432db3e)