### PR TITLE
Add API version fallback for UniFi Drive endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -21,6 +21,10 @@ class UniFiDriveClient:
         self._session: Optional[aiohttp.ClientSession] = None
         self._csrf: Optional[str] = None
         self._token_expire_ms: Optional[int] = None  # epoch ms from X-Token-Expire-Time
+        # Newer UniFi OS builds expose the Drive endpoints under ``/api/v2`` while
+        # older firmware still responds on ``/api/v1``.  Keep a preference ordered
+        # list so we can retry gracefully on 404s and remember the working prefix.
+        self._drive_api_versions: list[str] = ["v2", "v1"]
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session and not self._session.closed:
@@ -93,8 +97,19 @@ class UniFiDriveClient:
         if self._will_expire_within(300):  # 5 minutes
             await self.login()
 
-    async def _request_json(self, method: str, path: str, *, retry_on_401: bool = True) -> Any:
-        """Generic JSON request with single 401 reauth + retry."""
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        retry_on_401: bool = True,
+        return_on_404: bool = True,
+    ) -> Any:
+        """Generic JSON request with single 401 reauth + retry.
+
+        ``return_on_404`` allows callers that know about version fallbacks to
+        distinguish genuine missing endpoints from ``{}`` payloads.
+        """
         sess = await self._ensure_session()
         url = f"{self._base}{path}"
         headers = self._base_headers()
@@ -106,7 +121,9 @@ class UniFiDriveClient:
                 await self.login()
                 return await self._request_json(method, path, retry_on_401=False)
             if resp.status == 404:
-                return {}
+                if return_on_404:
+                    return {}
+                raise RuntimeError(f"HTTP 404 - {url}")
             if resp.status >= 400:
                 # Surface full message if possible
                 with suppress(Exception):
@@ -119,24 +136,58 @@ class UniFiDriveClient:
                 return await resp.json()
             return {}
 
+    async def _request_drive_json(self, method: str, suffix: str) -> Any:
+        """Request a UniFi Drive endpoint trying multiple API versions.
+
+        Some appliances only expose ``/proxy/drive/api/v1`` while others use
+        ``/proxy/drive/api/v2``.  Probe the known versions until one responds
+        successfully and memoise the working prefix so subsequent calls avoid an
+        extra round trip.
+        """
+
+        last_error: Optional[RuntimeError] = None
+        for version in tuple(self._drive_api_versions):
+            path = f"/proxy/drive/api/{version}/{suffix}"
+            try:
+                result = await self._request_json(method, path, return_on_404=False)
+            except RuntimeError as err:
+                last_error = err
+                # Try the next version if this one is simply missing.
+                if "HTTP 404" in str(err):
+                    continue
+                raise
+            else:
+                # Cache the working version at the front for faster lookups
+                if version != self._drive_api_versions[0]:
+                    self._drive_api_versions.remove(version)
+                    self._drive_api_versions.insert(0, version)
+                return result
+
+        # If every version failed with 404, surface the last error so callers can
+        # handle it (coordinator will wrap into UpdateFailed/AuthFailed as
+        # appropriate).
+        if last_error:
+            raise last_error
+        return {}
+
     # --- Endpoints ---
     async def get_device_info(self) -> dict[str, Any]:
-        return await self._request_json("GET", "/proxy/drive/api/v2/systems/device-info")
+        return await self._request_drive_json("GET", "systems/device-info")
 
     async def get_storage_root(self) -> dict[str, Any]:
-        return await self._request_json("GET", "/proxy/drive/api/v2/storage")
+        return await self._request_drive_json("GET", "storage")
 
     async def get_storage_shares(self) -> Any:
-        return await self._request_json("GET", "/proxy/drive/api/v2/shares")
+        return await self._request_drive_json("GET", "shares")
 
     async def get_storage_volumes(self) -> Any:
-        return await self._request_json("GET", "/proxy/drive/api/v2/volumes")
+        return await self._request_drive_json("GET", "volumes")
 
     async def get_drives(self) -> dict[str, Any]:
-        return await self._request_json("GET", "/proxy/drive/api/v2/drives")
+        return await self._request_drive_json("GET", "drives")
 
     async def get_fan_control(self) -> dict[str, Any]:
-        return await self._request_json("GET", "/proxy/drive/api/v2/systems/fan-control")
+        return await self._request_drive_json("GET", "systems/fan-control")
 
     async def get_all(self) -> dict[str, Any]:
         # Proactively keep session valid


### PR DESCRIPTION
## Summary
- add retry and memoisation logic to probe UniFi Drive API v2 and v1 endpoints
- propagate 404 handling so the coordinator can transparently use whichever version is available
- update all Drive data fetches to use the new helper

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174583823c832db5c801f91c93db31)