### PR TITLE
Bump actions/checkout to v6 to silence Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ jobs:
     name: HACS validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: HACS validation
         uses: hacs/action@main
@@ -27,7 +27,7 @@ jobs:
     name: Hassfest validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # hassfest expects the custom_components/<domain> layout, while this
       # repository keeps the integration in the root (hacs.json


### PR DESCRIPTION
Claude-Session: https://claude.ai/code/session_01W3aBiDb4kHE4Wc9Yc3NUSk